### PR TITLE
chore(deps-dev): updates dependency constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - gem install coveralls-lcov
 script:
   - pub get
-  - pub run test_coverage
+  - pub run coverage
 after_success:
   - coveralls-lcov --repo-token $COVERALLS_TOKEN coverage/lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.1]
+
+* Support Dart 3, while maintaining backward compatibility with Dart 2
+
 ## [2.0.0]
 
 * Support null-safety

--- a/lib/src/mrz_checkdigit_calculator.dart
+++ b/lib/src/mrz_checkdigit_calculator.dart
@@ -1,13 +1,13 @@
-part of mrz_parser;
+part of 'mrz_parser.dart';
 
 class MRZCheckDigitCalculator {
   MRZCheckDigitCalculator._();
 
   static final _weights = [7, 3, 1];
 
-  static int getCheckDigit(String input) {
+  static int getCheckDigit(final String input) {
     final checkSum = input.codeUnits
-        .map((c) {
+        .map((final c) {
           if (_isCapitalLetter(c)) {
             return c - _A + 10;
           }
@@ -18,16 +18,17 @@ class MRZCheckDigitCalculator {
         })
         .toList()
         .asMap()
-        .map((i, v) => MapEntry(i, v * _weights[i % _weights.length]))
+        .map((final i, final v) =>
+            MapEntry(i, v * _weights[i % _weights.length]))
         .values
-        .reduce((value, element) => value + element);
+        .reduce((final value, final element) => value + element);
 
     return checkSum % 10;
   }
 
-  static bool _isCapitalLetter(int c) => c >= _A && c <= _Z;
+  static bool _isCapitalLetter(final int c) => c >= _A && c <= _Z;
 
-  static bool _isDigit(int c) => c >= _0 && c <= _9;
+  static bool _isDigit(final int c) => c >= _0 && c <= _9;
 
   static const int _A = 65;
   static const int _Z = 90;

--- a/lib/src/mrz_field_parser.dart
+++ b/lib/src/mrz_field_parser.dart
@@ -1,19 +1,19 @@
-part of mrz_parser;
+part of 'mrz_parser.dart';
 
 class MRZFieldParser {
   MRZFieldParser._();
 
-  static String parseDocumentNumber(String input) => _trim(input);
+  static String parseDocumentNumber(final String input) => _trim(input);
 
-  static String parseDocumentType(String input) => _trim(input);
+  static String parseDocumentType(final String input) => _trim(input);
 
-  static String parseCountryCode(String input) => _trim(input);
+  static String parseCountryCode(final String input) => _trim(input);
 
-  static String parseNationality(String input) => _trim(input);
+  static String parseNationality(final String input) => _trim(input);
 
-  static String parseOptionalData(String input) => _trim(input);
+  static String parseOptionalData(final String input) => _trim(input);
 
-  static List<String> parseNames(String input) {
+  static List<String> parseNames(final String input) {
     final words = input.trimChar('<').split('<<');
     final result = [
       words.isNotEmpty ? _trim(words[0]) : '',
@@ -22,17 +22,17 @@ class MRZFieldParser {
     return result;
   }
 
-  static DateTime parseBirthDate(String input) {
+  static DateTime parseBirthDate(final String input) {
     final formattedInput = _formatDate(input);
     return _parseDate(formattedInput, DateTime.now().year - 2000);
   }
 
-  static DateTime parseExpiryDate(String input) {
+  static DateTime parseExpiryDate(final String input) {
     final formattedInput = _formatDate(input);
     return _parseDate(formattedInput, 70);
   }
 
-  static Sex parseSex(String input) {
+  static Sex parseSex(final String input) {
     switch (input) {
       case 'M':
         return Sex.male;
@@ -43,14 +43,14 @@ class MRZFieldParser {
     }
   }
 
-  static String _formatDate(String input) => _trim(input);
+  static String _formatDate(final String input) => _trim(input);
 
-  static DateTime _parseDate(String input, int milestoneYear) {
+  static DateTime _parseDate(final String input, final int milestoneYear) {
     final parsedYear = int.parse(input.substring(0, 2));
     final centennial = (parsedYear > milestoneYear) ? '19' : '20';
     return DateTime.parse(centennial + input);
   }
 
-  static String _trim(String input) =>
+  static String _trim(final String input) =>
       input.replaceAngleBracketsWithSpaces().trim();
 }

--- a/lib/src/mrz_field_recognition_defects_fixer.dart
+++ b/lib/src/mrz_field_recognition_defects_fixer.dart
@@ -1,25 +1,25 @@
-part of mrz_parser;
+part of 'mrz_parser.dart';
 
 class MRZFieldRecognitionDefectsFixer {
   MRZFieldRecognitionDefectsFixer._();
 
-  static String fixDocumentType(String input) =>
+  static String fixDocumentType(final String input) =>
       input.replaceSimilarDigitsWithLetters();
 
-  static String fixCheckDigit(String input) =>
+  static String fixCheckDigit(final String input) =>
       input.replaceSimilarLettersWithDigits();
 
-  static String fixDate(String input) =>
+  static String fixDate(final String input) =>
       input.replaceSimilarLettersWithDigits();
 
-  static String fixSex(String input) => input.replaceAll('P', 'F');
+  static String fixSex(final String input) => input.replaceAll('P', 'F');
 
-  static String fixCountryCode(String input) =>
+  static String fixCountryCode(final String input) =>
       input.replaceSimilarDigitsWithLetters();
 
-  static String fixNames(String input) =>
+  static String fixNames(final String input) =>
       input.replaceSimilarDigitsWithLetters();
 
-  static String fixNationality(String input) =>
+  static String fixNationality(final String input) =>
       input.replaceSimilarDigitsWithLetters();
 }

--- a/lib/src/mrz_parser.dart
+++ b/lib/src/mrz_parser.dart
@@ -19,7 +19,7 @@ class MRZParser {
   /// Like [parse] except that this function returns `null` where a
   /// similar call to [parse] would throw a [MRZException]
   /// in case of invalid input or unsuccessful parsing
-  static MRZResult? tryParse(List<String?>? input) {
+  static MRZResult? tryParse(final List<String?>? input) {
     try {
       return parse(input);
     } on Exception {
@@ -34,7 +34,7 @@ class MRZParser {
   ///
   /// If [input] format is invalid or parsing was unsuccessful,
   /// an instance of [MRZException] is thrown
-  static MRZResult parse(List<String?>? input) {
+  static MRZResult parse(final List<String?>? input) {
     final polishedInput = _polishInput(input);
     if (polishedInput == null) {
       throw const InvalidMRZInputException();
@@ -53,14 +53,18 @@ class MRZParser {
     throw const InvalidMRZInputException();
   }
 
-  static List<String>? _polishInput(List<String?>? input) {
+  static List<String>? _polishInput(final List<String?>? input) {
     if (input == null) {
       return null;
     }
 
-    final polishedInput =
-        input.where((s) => s != null).map((s) => s!.toUpperCase()).toList();
+    final polishedInput = input
+        .where((final s) => s != null)
+        .map((final s) => s!.toUpperCase())
+        .toList();
 
-    return polishedInput.any((s) => !s.isValidMRZInput) ? null : polishedInput;
+    return polishedInput.any((final s) => !s.isValidMRZInput)
+        ? null
+        : polishedInput;
   }
 }

--- a/lib/src/mrz_result.dart
+++ b/lib/src/mrz_result.dart
@@ -28,7 +28,7 @@ class MRZResult {
   final String? personalNumber2;
 
   @override
-  bool operator ==(Object other) =>
+  bool operator ==(final Object other) =>
       identical(this, other) ||
       other is MRZResult &&
           runtimeType == other.runtimeType &&

--- a/lib/src/mrz_string_extensions.dart
+++ b/lib/src/mrz_string_extensions.dart
@@ -1,11 +1,11 @@
-part of mrz_parser;
+part of 'mrz_parser.dart';
 
 extension _MRZStringExtensions on String {
   static final _validInput = RegExp(r'^[A-Z|0-9|<]+$');
 
   bool get isValidMRZInput => _validInput.hasMatch(this);
 
-  String trimChar(String char) {
+  String trimChar(final String char) {
     if (isEmpty || char.isEmpty) {
       return this;
     }

--- a/lib/src/td1_format_mrz_parser.dart
+++ b/lib/src/td1_format_mrz_parser.dart
@@ -1,4 +1,4 @@
-part of mrz_parser;
+part of 'mrz_parser.dart';
 
 class _TD1MRZFormatParser {
   _TD1MRZFormatParser._();
@@ -6,11 +6,11 @@ class _TD1MRZFormatParser {
   static const _linesLength = 30;
   static const _linesCount = 3;
 
-  static bool isValidInput(List<String> input) =>
+  static bool isValidInput(final List<String> input) =>
       input.length == _linesCount &&
-      input.every((s) => s.length == _linesLength);
+      input.every((final s) => s.length == _linesLength);
 
-  static MRZResult parse(List<String> input) {
+  static MRZResult parse(final List<String> input) {
     if (!isValidInput(input)) {
       throw const InvalidMRZInputException();
     }

--- a/lib/src/td2_format_mrz_parser.dart
+++ b/lib/src/td2_format_mrz_parser.dart
@@ -1,4 +1,4 @@
-part of mrz_parser;
+part of 'mrz_parser.dart';
 
 class _TD2MRZFormatParser {
   _TD2MRZFormatParser._();
@@ -6,11 +6,11 @@ class _TD2MRZFormatParser {
   static const _linesLength = 36;
   static const _linesCount = 2;
 
-  static bool isValidInput(List<String> input) =>
+  static bool isValidInput(final List<String> input) =>
       input.length == _linesCount &&
-      input.every((s) => s.length == _linesLength);
+      input.every((final s) => s.length == _linesLength);
 
-  static MRZResult parse(List<String> input) {
+  static MRZResult parse(final List<String> input) {
     if (!isValidInput(input)) {
       throw const InvalidMRZInputException();
     }
@@ -124,10 +124,10 @@ class _TD2MRZFormatParser {
     );
   }
 
-  static bool _isFrenchId(List<String> input) =>
+  static bool _isFrenchId(final List<String> input) =>
       input[0][0] == 'I' && input[0].substring(2, 5) == 'FRA';
 
-  static MRZResult _parseFrenchId(List<String> input) {
+  static MRZResult _parseFrenchId(final List<String> input) {
     final firstLine = input[0];
     final secondLine = input[1];
 
@@ -200,11 +200,11 @@ class _TD2MRZFormatParser {
     final documentType = MRZFieldParser.parseDocumentType(documentTypeFixed);
     final countryCode = MRZFieldParser.parseCountryCode(countryCodeFixed);
     final givenNames = MRZFieldParser.parseNames(givenNamesFixed)
-        .where((element) => element.isNotEmpty)
+        .where((final element) => element.isNotEmpty)
         .toList()
         .join(' ');
     final lastNames = MRZFieldParser.parseNames(lastNamesFixed)
-        .where((element) => element.isNotEmpty)
+        .where((final element) => element.isNotEmpty)
         .toList()
         .join(' ');
     final documentNumber =

--- a/lib/src/td3_format_mrz_parser.dart
+++ b/lib/src/td3_format_mrz_parser.dart
@@ -1,4 +1,4 @@
-part of mrz_parser;
+part of 'mrz_parser.dart';
 
 class _TD3MRZFormatParser {
   _TD3MRZFormatParser._();
@@ -6,11 +6,11 @@ class _TD3MRZFormatParser {
   static const _linesLength = 44;
   static const _linesCount = 2;
 
-  static bool isValidInput(List<String> input) =>
+  static bool isValidInput(final List<String> input) =>
       input.length == _linesCount &&
-      input.every((s) => s.length == _linesLength);
+      input.every((final s) => s.length == _linesLength);
 
-  static MRZResult parse(List<String> input) {
+  static MRZResult parse(final List<String> input) {
     if (!isValidInput(input)) {
       throw const InvalidMRZInputException();
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,386 +5,377 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0816708f5fbcacca324d811297153fe3c8e047beb5c6752e12292d2974c17045"
+      url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "62.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "21862995c9932cd082f89d72ae5f5e2c110d1a0204ad06e4ebaee8307b76b834"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.41.2"
+    version: "6.0.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
+    version: "2.1.1"
   collection:
     dependency: "direct dev"
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.1"
   coverage:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.3"
+  dart_internal:
+    dependency: transitive
+    description:
+      name: dart_internal
+      sha256: dae3976f383beddcfcd07ad5291a422df2c8c0a8a03c52cda63ac7b4f26e0f4e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   extra_pedantic:
     dependency: "direct dev"
     description:
       name: extra_pedantic
-      url: "https://pub.dartlang.org"
+      sha256: de6407d96ae98e15168bc18111b4b8735f70ac089a860b6377be25529df07ca3
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "4.0.0"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "7.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.1.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.17.0"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
-  json_annotation:
-    dependency: transitive
-    description:
-      name: json_annotation
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.1"
-  lcov:
-    dependency: transitive
-    description:
-      name: lcov
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.7.0"
+    version: "0.6.7"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.11.4"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.16"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.3"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
+    version: "1.8.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.4"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.4"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "67ec5684c7a19b2aba91d2831f3d305a6fd8e1504629c5818f8d64478abf4f38"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.5"
+    version: "1.24.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.19"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "6b753899253c38ca0523bb0eccff3934ec83d011705dae717c61ecf209e333c9"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.15"
-  test_coverage:
-    dependency: "direct dev"
-    description:
-      name: test_coverage
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
+    version: "0.5.4"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: b8c67f5fa3897b122cf60fe9ff314f7b0ef71eab25c5f8b771480bc338f48823
+      url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "11.7.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.12.0-0.beta <3.0.0"
+  dart: ">=3.0.0 <3.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mrz_parser
 description: Parse MRZ (Machine Readable Zone) from identity documents.
-version: 2.1.0
+version: 2.0.1
 homepage: https://github.com/olexale/mrz_parser
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,13 @@
 name: mrz_parser
 description: Parse MRZ (Machine Readable Zone) from identity documents.
-version: 2.0.0
-authors:
-  - Anna Domashych <anna.domashych@gmail.com>
-  - Oleksandr Leuschenko <olexa.le@gmail.com>
+version: 2.1.0
 homepage: https://github.com/olexale/mrz_parser
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <4.0.0"
 
 dev_dependencies:
-  collection: ^1.15.0
-  extra_pedantic: ^1.3.0
-  test: '>=1.16.5 <2.0.0'
-  test_coverage: ^0.5.0
+  collection: ">=1.15.0"
+  coverage: ^1.6.3
+  extra_pedantic: ^4.0.0
+  test: ">=1.16.5 <2.0.0"

--- a/test/mrz_parser_test.dart
+++ b/test/mrz_parser_test.dart
@@ -2,10 +2,11 @@ import 'package:mrz_parser/mrz_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final expectResult = ({List<String?>? input, MRZResult? expectedOutput}) =>
+  final expectResult = (
+          {final List<String?>? input, final MRZResult? expectedOutput}) =>
       expect(MRZParser.parse(input), expectedOutput);
 
-  final expectException = <T>({List<String?>? input}) =>
+  final expectException = <T>({final List<String?>? input}) =>
       expect(() => MRZParser.parse(input), throwsA(isA<T>()));
 
   group('invalid input throws $InvalidMRZInputException', () {


### PR DESCRIPTION
Makes the package work with Dart 3 and newer versions of its dev_dependencies. The code was also modified to fit the newer version of the linter used.